### PR TITLE
Upgrade to Node 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jdk
 
 # Node.js
 
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 	&& apt-get install -y nodejs \
 	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docker image for Node.js automated UI tests.
 Includes:
 
 * JDK 8
-* Node.js 7.x
+* Node.js 8.x
 * Chrome (latest)
 * Xvfb
 


### PR DESCRIPTION
I would propose that the docker image is upgraded to use node@8 (which is LTS).

Related to https://github.com/facebook/jest/pull/4875#discussion_r150941499